### PR TITLE
Update template name parsing to handle more cases

### DIFF
--- a/src/jquery-autobars.js
+++ b/src/jquery-autobars.js
@@ -20,7 +20,7 @@
     },
     parseName:function(url) {
       var split_url = url.split("/");
-      //get every past the last slash
+      //get everything past the last slash
       var name = split_url[split_url.length-1];
       //strip querystring
       name = name.split("?")[0];


### PR DESCRIPTION
Currently the regex used for parsing the template name will not support a script file with a querystring, which is the case for people using frameworks with versioned or cached statics. This is a non-regex version that will handle a few different naming conventions as well as querystrings.

It will handle files without extensions. It will handle multiple periods in the file name - with the caveat that it will assume these files have an extension. ( There isn't a clean way to handle the other case ) It will also, of course, handle querystrings.

Examples:
"view.panel.hbs?v=123" = "view.panel"
"view.panel" = "view"
"view-panel" = "view-panel"
