### PR TITLE
Fix API mispelling

### DIFF
--- a/src/jquery-autobars.js
+++ b/src/jquery-autobars.js
@@ -64,7 +64,7 @@
 			}
 		},
 		registerPartial: function(key, partial) {
-			Handlebars.registerParial(key, partial);
+			Handlebars.registerPartial(key, partial);
 		},
 		mainTemplates: function(context) {
 			var pipe = [];//promise objects


### PR DESCRIPTION
This was missing the "t", causing it to fail
